### PR TITLE
Add reference-source jars to ensime config

### DIFF
--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
@@ -42,6 +42,8 @@ class ConfigGenerator(
     val project: MavenProject,
     val properties: Properties) {
 
+  val jarPattern = "\\.jar$".r
+
   def getJavaHome(): String = {
     SystemUtils.getJavaHome().getPath()
   }
@@ -133,6 +135,7 @@ class ConfigGenerator(
 
         val sourceRoots = project.getCompileSourceRoots.asInstanceOf[JList[String]] ++: project.getTestCompileSourceRoots.asInstanceOf[JList[String]] ++: Nil
         val scalaRoots = getScalaSourceRoots(sourceRoots)
+        val allDeps = (runtimeDeps ++ compileDeps ++ testDeps).toSet
 
         SubProject(
           project.getArtifactId,
@@ -151,7 +154,16 @@ class ConfigGenerator(
           scalaRoots ++: sourceRoots,
           project.getBuild.getOutputDirectory,
           project.getBuild.getTestOutputDirectory,
-          dependsOnModules.toList.map(_.getArtifactId))
+          dependsOnModules.toList.map(_.getArtifactId),
+          allDeps.foldLeft(List[String]()) { (output, dep) =>
+            val sourceJar = jarPattern.replaceFirstIn(dep, "-sources.jar")
+            if (new java.io.File(sourceJar).exists) {
+              sourceJar :: output
+            } else {
+              output
+            }
+          }
+        )
       }
     }
 

--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/model/SubProject.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/model/SubProject.scala
@@ -37,7 +37,8 @@ case class SubProject(
   sourceRoots: List[String],
   target: String,
   testTarget: String,
-  dependsOnModules: List[String])
+  dependsOnModules: List[String],
+  referenceSourceRoots: List[String])
 
 /**
  * A companion object for {@link SubProject}.
@@ -61,6 +62,7 @@ object SubProject {
         (SKeyword("source-roots") -> SList(subproject.sourceRoots.map(SString(_)))),
         (SKeyword("target") -> SString(subproject.target)),
         (SKeyword("test-target") -> SString(subproject.testTarget)),
+        (SKeyword("reference-source-roots") -> SList(subproject.referenceSourceRoots.map(SString(_)))),
         (SKeyword("depends-on-modules") -> SList(subproject.dependsOnModules.map(SString(_))))))
   }
 }

--- a/src/test/scala/st/happy_camper/maven/plugins/ensime/model/ProjectSpec.scala
+++ b/src/test/scala/st/happy_camper/maven/plugins/ensime/model/ProjectSpec.scala
@@ -43,7 +43,8 @@ class ProjectSpec extends Specification {
         List("source-root-1", "source-root-2"),
         "target",
         "test-target",
-        List("depends-1", "depends-2"))),
+        List("depends-1", "depends-2"),
+        List("depends-src-1", "depends-src-2"))),
         FormatterPreferences())
 
       val expected = """(:root-dir
@@ -83,6 +84,9 @@ class ProjectSpec extends Specification {
                        |     :depends-on-modules
                        |       ("depends-1"
                        |        "depends-2")))
+                       |     :reference-source-roots
+                       |       ("depends-src-1"
+                       |        "depends-src-2")))
                        | :formatting-prefs
                        |   ())""".stripMargin
 

--- a/src/test/scala/st/happy_camper/maven/plugins/ensime/model/SubProjectSpec.scala
+++ b/src/test/scala/st/happy_camper/maven/plugins/ensime/model/SubProjectSpec.scala
@@ -43,7 +43,8 @@ class SubProjectSpec extends Specification {
         List("source-root-1", "source-root-2"),
         "target",
         "test-target",
-        List("depends-1", "depends-2"))
+        List("depends-1", "depends-2"),
+        List("depends-src-1", "depends-src-2"))
       subproject.as[SExpr].as[String] must equalTo("""(:name
                                                      |   "name"
                                                      | :module-name
@@ -66,7 +67,10 @@ class SubProjectSpec extends Specification {
                                                      |   "test-target"
                                                      | :depends-on-modules
                                                      |   ("depends-1"
-                                                     |    "depends-2"))""".stripMargin)
+                                                     |    "depends-2")
+                                                     | :reference-source-roots
+                                                     |   ("depends-src-1"
+                                                     |   "depends-src-2"))""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
Doesn't automatically fetch the sources, but if they've already been
fetched (such as by running `mvn dependency:source`), then it will
attempt to detect them and add the one's that actually exist in the file
system to the ensime config file.