### PR TITLE
Maven is run as jre, so attempt to get jdk home

### DIFF
--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
@@ -43,7 +43,7 @@ class ConfigGenerator(
     val properties: Properties) {
 
   def getJavaHome(): String = {
-    SystemUtils.getJavaHome().getPath()
+    SystemUtils.getJavaHome().getPath().replaceFirst("/jre$", "")
   }
 
   /**


### PR DESCRIPTION
`SystemUtils.getJavaHome().getPath()` returns the home of the jre, which
doesn't work for running ensime. Generally, if someone has the jdk
installed, they correct home is the path without the added "/jre".

This is a very dumb, hacky fix, but works for me on both my OS X and
Linux boxes. I welcome alternative ideas that don't rely on me opening
up the generated ensime file everytime and manually fixing it.

Example found path from my OS X machine:
"/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/jre"

changes to:
"/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home"