### PR TITLE
Less hacky logic to find JDK instead of JRE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .cache
 .scala_dependencies
 .ensime*
+.projectile

--- a/pom.xml
+++ b/pom.xml
@@ -283,11 +283,6 @@
       <artifactId>maven-plugin-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>


### PR DESCRIPTION
Maven runs as JRE, not JDK, so we need to do some sleuthing to find the
JDK required for ensime to run.

*Heavily* inspired by
https://github.com/ensime/ensime-server/blob/b4ec3c9f411a960f23f48aa1e015a2c406110fd8/project/EnsimeBuild.scala#L371

Also:
- Remove (now) unused dependency org.apache.commons.lang3
- add .projectile to the .gitignore list