### PR TITLE
Update default scala version

### DIFF
--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/ConfigGenerator.scala
@@ -84,7 +84,7 @@ class ConfigGenerator(
    * @author parsnips
    */
   def getScalaVersion(): String = {
-    Option(project.getProperties().getProperty("scala.version")).getOrElse("2.9.2") // So arbitrary.
+    Option(project.getProperties().getProperty("scala.version")).getOrElse("2.10.6") // So arbitrary.
   }
 
   /**


### PR DESCRIPTION
If we attempt to run ensime with the current default version of 2.9.2,
we get the following dependency errors:

```
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: com.typesafe.akka#akka-actor;2.0.5: not found
[warn] 	:: com.typesafe.akka#akka-slf4j;2.0.5: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::

```

Updating to to 2.10.6 fixes this issue.

If you're wondering how I got into this mess, it's because I've started
to use ensime to replace eclim for working with Java in Emacs on my
maven projects, which don't have a scala dependency of their own.