### PR TITLE
Add support for int output to `.ensime` files

### DIFF
--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/model/FormatterPreferences.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/model/FormatterPreferences.scala
@@ -34,7 +34,7 @@ case class FormatterPreferences(
     alignParameters: Option[Boolean] = None,
     doubleIndentClassDeclaration: Option[Boolean] = None,
     alignSingleLineCaseStatements: Option[Boolean] = None,
-    //alignSingleLineCaseStatements_maxArrowIndent: Option[Int] = None,
+    alignSingleLineCaseStatements_maxArrowIndent: Option[Int] = None,
     indentPackageBlocks: Option[Boolean] = None,
     indentLocalDefs: Option[Boolean] = None,
 
@@ -77,7 +77,7 @@ object FormatterPreferences {
       alignParameters = Option(properties.getProperty("alignParameters")).map(_.toBoolean),
       doubleIndentClassDeclaration = Option(properties.getProperty("doubleIndentClassDeclaration")).map(_.toBoolean),
       alignSingleLineCaseStatements = Option(properties.getProperty("alignSingleLineCaseStatements")).map(_.toBoolean),
-      //alignSingleLineCaseStatements_maxArrowIndent = Option(properties.getProperty("alignSingleLineCaseStatements.maxArrowIndent")).map(_.toInt),
+      alignSingleLineCaseStatements_maxArrowIndent = Option(properties.getProperty("alignSingleLineCaseStatements.maxArrowIndent")).map(_.toInt),
       indentPackageBlocks = Option(properties.getProperty("indentPackageBlocks")).map(_.toBoolean),
       indentLocalDefs = Option(properties.getProperty("indentLocalDefs")).map(_.toBoolean),
 
@@ -113,7 +113,7 @@ object FormatterPreferences {
           fp.alignParameters.map(b => ("alignParameters".as[SKeyword], b.as[SExpr])).toList :::
           fp.doubleIndentClassDeclaration.map(b => ("doubleIndentClassDeclaration".as[SKeyword], b.as[SExpr])).toList :::
           fp.alignSingleLineCaseStatements.map(b => ("alignSingleLineCaseStatements".as[SKeyword], b.as[SExpr])).toList :::
-          //fp.alignSingleLineCaseStatements_maxArrowIndent.map(i => ("alignSingleLineCaseStatements_maxArrowIndent".as[SKeyword], i.as[SExpr])).toList :::
+          fp.alignSingleLineCaseStatements_maxArrowIndent.map(i => ("alignSingleLineCaseStatements.maxArrowIndent".as[SKeyword], i.as[SExpr])).toList :::
           fp.indentPackageBlocks.map(b => ("indentPackageBlocks".as[SKeyword], b.as[SExpr])).toList :::
           fp.indentLocalDefs.map(b => ("indentLocalDefs".as[SKeyword], b.as[SExpr])).toList :::
 

--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExpr.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExpr.scala
@@ -27,6 +27,7 @@ import scalax.io.JavaConverters._
  */
 sealed trait SExpr
 case class SString(value: String) extends SExpr
+case class SInt(value: Int) extends SExpr
 case object STrue extends SExpr
 case object SNil extends SExpr
 case class SKeyword(keyword: String) extends SExpr
@@ -69,7 +70,7 @@ object SExpr {
   implicit object IntAsSExpr extends As[Int, SExpr] {
 
     override def as(i: Int) = {
-      SString(i.toString)
+      SInt(i)
     }
   }
 

--- a/src/main/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExprEmitter.scala
+++ b/src/main/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExprEmitter.scala
@@ -37,6 +37,7 @@ class SExprEmitter(val sexpr: SExpr) {
   @inline
   private def emitSExpr(out: Output, sexpr: SExpr, indent: Int = 0): Unit = sexpr match {
     case SString(value)    => emitSString(out, value)
+    case SInt(value)       => emitSInt(out, value)
     case STrue             => emitSTrue(out)
     case SNil              => emitSNil(out)
     case SKeyword(keyword) => emitSKeyword(out, keyword)
@@ -46,6 +47,9 @@ class SExprEmitter(val sexpr: SExpr) {
 
   @inline
   private def emitSString(out: Output, value: String) = out.write("\"" + value + "\"")
+
+  @inline
+  private def emitSInt(out: Output, value: Int) = out.write(value.toString)
 
   @inline
   private def emitSTrue(out: Output) = out.write("t")

--- a/src/test/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExprEmitterSpec.scala
+++ b/src/test/scala/st/happy_camper/maven/plugins/ensime/sexpr/SExprEmitterSpec.scala
@@ -45,6 +45,15 @@ class SExprEmitterSpec extends Specification {
       out.toString must equalTo("\"string\"")
     }
 
+    "emit S-Int" in new Context {
+      val sstring = SInt(5)
+
+      val emitter = new SExprEmitter(sstring)
+      emitter.emit(out.asOutput)
+
+      out.toString must equalTo("5")
+    }
+
     "emit S-True" in new Context {
       val strue = STrue
 


### PR DESCRIPTION
Certain items in :formatting-prefs are supposed to be integers, not
strings, so add support for these.

Specific item that was causing issues for me was `indentSpaces` in this
project itself, which would print as `:indentSpaces "2"`, which unless I
deleted that particular line would prevent ensime from starting up to
hack around on this project. With this change, it now goes into the
`.ensime` file as `:indentSpaces 2`.