### PR TITLE
Configure scalariform to run automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,44 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>${project.artifactId}</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.scalariform</groupId>
+        <artifactId>scalariform-maven-plugin</artifactId>
+        <version>0.1.4</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+            <configuration>
+              <indentSpaces>2</indentSpaces>
+              <indentWithTabs>false</indentWithTabs>
+              <alignParameters>true</alignParameters>
+              <doubleIndentClassDeclaration>true</doubleIndentClassDeclaration>
+              <alignSingleLineCaseStatements>true</alignSingleLineCaseStatements>
+              <alignSingleLineCaseStatements.maxArrowIndent>40</alignSingleLineCaseStatements.maxArrowIndent>
+              <indentPackageBlocks>true</indentPackageBlocks>
+              <indentLocalDefs>false</indentLocalDefs>
+              <!-- Spaces -->
+              <spaceBeforeColon>false</spaceBeforeColon>
+              <compactStringConcatenation>false</compactStringConcatenation>
+              <spaceInsideBrackets>false</spaceInsideBrackets>
+              <spaceInsideParentheses>false</spaceInsideParentheses>
+              <preserveSpaceBeforeArguments>false</preserveSpaceBeforeArguments>
+              <spacesWithinPatternBinders>true</spacesWithinPatternBinders>
+              <!-- Scaladoc -->
+              <multilineScaladocCommentsStartOnFirstLine>false</multilineScaladocCommentsStartOnFirstLine>
+              <placeScaladocAsterisksBeneathSecondAsterisk>false</placeScaladocAsterisksBeneathSecondAsterisk>
+              <!-- Miscellaneous -->
+              <formatXml>true</formatXml>
+              <rewriteArrowSymbols>false</rewriteArrowSymbols>
+              <preserveDanglingCloseParenthesis>false</preserveDanglingCloseParenthesis>
+              <compactControlReadability>false</compactControlReadability>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
@@ -15,7 +15,7 @@
  */
 package org.ensime.maven.plugins.ensime
 
-import java.io.{File, FileOutputStream, FileNotFoundException}
+import java.io.{ File, FileOutputStream, FileNotFoundException }
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.{ List => JList }
@@ -51,17 +51,15 @@ class ConfigGenerator(
       Option("/usr/libexec/java_home"),
       // fallback
       sys.props.get("java.home").map(new File(_).getParent),
-      sys.props.get("java.home")
-    ).flatten.map { n =>
-      // Make sure we're dealing with the JDK by seeing if `javac` exists
-      new File (n.trim + File.separator + "bin" + File.separator + "javac")
-    }.filter(_.exists())
+      sys.props.get("java.home")).flatten.map { n =>
+        // Make sure we're dealing with the JDK by seeing if `javac` exists
+        new File(n.trim + File.separator + "bin" + File.separator + "javac")
+      }.filter(_.exists())
       .map(_.getParentFile.getParent)
       .headOption.getOrElse(
-      throw new FileNotFoundException(
-        """Could not automatically find the JRE home directory.
-        |You must explicitly set JDK_HOME or JAVA_HOME.""".stripMargin
-      ))
+        throw new FileNotFoundException(
+          """Could not automatically find the JRE home directory.
+        |You must explicitly set JDK_HOME or JAVA_HOME.""".stripMargin))
   }
 
   /**
@@ -73,7 +71,7 @@ class ConfigGenerator(
   def getEnsimeJavaFlags(): List[String] = {
     Option(System.getenv("ENSIME_JAVA_FLAGS")) match {
       case Some(flags) => parser.JavaFlagsParser(flags)
-      case _ => List()
+      case _           => List()
     }
   }
 
@@ -163,10 +161,10 @@ class ConfigGenerator(
             module.getBuild.getOutputDirectory
           }),
           testDeps,
-            // TODO: File a bug against ensime-server, cuz this breaks shit
-            // ::: ((dependsOnModules.toList :+ project).map { module =>
-            //module.getBuild.getOutputDirectory
-            //} :+ project.getBuild.getTestOutputDirectory),
+          // TODO: File a bug against ensime-server, cuz this breaks shit
+          // ::: ((dependsOnModules.toList :+ project).map { module =>
+          //module.getBuild.getOutputDirectory
+          //} :+ project.getBuild.getTestOutputDirectory),
           scalaRoots ++: sourceRoots,
           project.getBuild.getOutputDirectory,
           project.getBuild.getTestOutputDirectory,
@@ -178,8 +176,7 @@ class ConfigGenerator(
             } else {
               output
             }
-          }
-        )
+          })
       }
     }
 

--- a/src/main/scala/org/ensime/maven/plugins/ensime/parser/JavaFlagsParser.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/parser/JavaFlagsParser.scala
@@ -14,6 +14,6 @@ object JavaFlagsParser extends RegexParsers {
 
   def apply(input: String) = parseAll(args, input) match {
     case Success(result, _) => result._1
-    case NoSuccess(_, _) => throw new IllegalArgumentException("Could not parse java flags")
+    case NoSuccess(_, _)    => throw new IllegalArgumentException("Could not parse java flags")
   }
 }

--- a/src/test/scala/org/ensime/maven/plugins/ensime/model/ProjectSpec.scala
+++ b/src/test/scala/org/ensime/maven/plugins/ensime/model/ProjectSpec.scala
@@ -34,7 +34,7 @@ class ProjectSpec extends Specification {
   "Project" should {
 
     "be treated as SExpr" in {
-      val project = Project("name","path", "cache", "version", "java-home", List("-first", "-second"), List(SubProject(
+      val project = Project("name", "path", "cache", "version", "java-home", List("-first", "-second"), List(SubProject(
         "name",
         "version",
         List("runtime-dep-1", "runtime-dep-2"),
@@ -90,8 +90,8 @@ class ProjectSpec extends Specification {
                        | :formatting-prefs
                        |   ())""".stripMargin
 
-        val output = project.as[SExpr].as[String]
-        output must equalTo(expected)
+      val output = project.as[SExpr].as[String]
+      output must equalTo(expected)
     }
   }
 }


### PR DESCRIPTION
In my last PR (https://github.com/ensime/ensime-maven/pull/13), I
mentioned that we should actually run scalariform on this project. So,
here that is. The config is taken from
https://github.com/tanzoniteblack/ensime-maven/blob/scalariform/src/ensime/formatter.properties
, but I actually have no strong preferences one way or the other on any
of these values.

Note: The way that I set up the pom.xml, it will run scalariform
automatically when you compile the code, but you can also run it manually with `mvn process-sources`