### PR TITLE
Update distribution management

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
     - SCALA_VERSION=2.10.6
   commands:
     - git log | head -n 20
-    - mvn clean install
+    - mvn clean install -Dgpg.skip=true
     - if [ "$CI_BRANCH" = "master" ] ; then
-        mvn publish ;
+        mvn publish -Dgpg.skip=true;
       fi

--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,17 @@
     <url>http://github.com/ensime/ensime-maven/issues</url>
   </issueManagement>
 
+  <distributionManagement>
+	<snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+	</snapshotRepository>
+	<repository>
+      <id>sonatype-nexus</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+	</repository>
+  </distributionManagement>
+
   <properties>
     <mavenVersion>2.0.11</mavenVersion>
     <maven.test.jvmargs>-Xmx1024m</maven.test.jvmargs>
@@ -137,6 +148,20 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+	  <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-gpg-plugin</artifactId>
+		<version>1.5</version>
+		<executions>
+          <execution>
+			<id>sign-artifacts</id>
+			<phase>verify</phase>
+			<goals>
+              <goal>sign</goal>
+			</goals>
+          </execution>
+		</executions>
       </plugin>
     </plugins>
     <pluginManagement>


### PR DESCRIPTION
Update the distributionManagement to be able to deploy changes to
sonatype's repositories.

I've already pushed a snapshot version of the artifact (https://oss.sonatype.org/content/repositories/snapshots/org/ensime/maven/plugins/ensime-maven/0.0.3-SNAPSHOT/), and if everyone's ok with the config I've set up for maven deployment, I'll go ahead and push a `0.0.3` "stable" version and update the version number to `0.0.4-SNAPSHOT` (unless there's a different procedure I should be following).