### PR TITLE
Ignore pom artifact types

### DIFF
--- a/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
@@ -133,16 +133,23 @@ class ConfigGenerator(
               if (artifactIdToModule.contains(artifactId)) {
                 (dependsOnModules + artifactIdToModule(artifactId), runtimeDeps, compileDeps, testDeps)
               } else {
-                val path = artifact.getFile.getAbsolutePath
-                artifact.getScope match {
-                  case Artifact.SCOPE_PROVIDED =>
-                    (dependsOnModules, runtimeDeps, path :: compileDeps, path :: testDeps)
-                  case Artifact.SCOPE_RUNTIME =>
-                    (dependsOnModules, path :: runtimeDeps, compileDeps, path :: testDeps)
-                  case Artifact.SCOPE_TEST =>
-                    (dependsOnModules, runtimeDeps, compileDeps, path :: testDeps)
-                  case _ =>
-                    (dependsOnModules, path :: runtimeDeps, path :: compileDeps, path :: testDeps)
+                // make sure we're only loading jars, otherwise ensime will have
+                // issues. Not sure if we should include `ejb-client` or not,
+                // but definitely throws errors on `pom` files
+                if (artifact.getType().matches("(test-)?jar")) {
+                  val path = artifact.getFile.getAbsolutePath
+                  artifact.getScope match {
+                    case Artifact.SCOPE_PROVIDED =>
+                      (dependsOnModules, runtimeDeps, path :: compileDeps, path :: testDeps)
+                    case Artifact.SCOPE_RUNTIME =>
+                      (dependsOnModules, path :: runtimeDeps, compileDeps, path :: testDeps)
+                    case Artifact.SCOPE_TEST =>
+                      (dependsOnModules, runtimeDeps, compileDeps, path :: testDeps)
+                    case _ =>
+                      (dependsOnModules, path :: runtimeDeps, path :: compileDeps, path :: testDeps)
+                  }
+                } else {
+                  (dependsOnModules, runtimeDeps, compileDeps, testDeps)
                 }
               }
           }


### PR DESCRIPTION
One of my projects has a dependency that looks like:

```xml
<dependency>
	<groupId>com.github.fommil.netlib</groupId>
	<artifactId>all</artifactId>
	<version>1.1.2</version>
	<type>pom</type>
</dependency>
```

This ends up going into the `.ensime` file along with all the dependency
jars, and then causes ensime to throw an error because it's not a zip
file. So let's just avoid putting anything into the the source roots
unless it's a jar type file according to the artifact data.