### PR TITLE
Fix for https://github.com/ensime/ensime-maven/issues/21

### DIFF
--- a/src/main/scala/org/ensime/maven/plugins/ensime/sexpr/SExprEmitter.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/sexpr/SExprEmitter.scala
@@ -46,7 +46,7 @@ class SExprEmitter(val sexpr: SExpr) {
   }
 
   @inline
-  private def emitSString(out: Output, value: String) = out.write("\"" + value + "\"")
+  private def emitSString(out: Output, value: String) = out.write("\"" + value.replace("\\", "/") + "\"")
 
   @inline
   private def emitSInt(out: Output, value: Int) = out.write(value.toString)


### PR DESCRIPTION
+ on Windows, check for javac.exe instead of javac when  verifying if JDK is installed.

+ escape the backslashes in paths (Windows paths have backslash as file separator).