### PR TITLE
Only run mvn deploy for master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,6 @@ build:
   commands:
     - git log | head -n 20
     - mvn clean install -Dgpg.skip=true
-    - if [ "$CI_BRANCH" = "master" ] ; then
+    - if [ "$CIRCLE_BRANCH" = "master" ] ; then
         mvn deploy -s .settings.xml -Dgpg.skip=true;
       fi


### PR DESCRIPTION
Change it to check what I *think* is the right environment variable. Not sure why `$CI_BRANCH` is set to master anyways, despite it not seeming to exist in the documentation.