### PR TITLE
Add support for javadocs

### DIFF
--- a/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/ConfigGenerator.scala
@@ -182,6 +182,14 @@ class ConfigGenerator(
             } else {
               output
             }
+          },
+          allDeps.foldLeft(List[String]()) { (output, dep) =>
+            val docJar = jarPattern.replaceFirstIn(dep, "-javadoc.jar")
+            if (new java.io.File(docJar).exists) {
+              docJar :: output
+            } else {
+              output
+            }
           })
       }
     }

--- a/src/main/scala/org/ensime/maven/plugins/ensime/model/SubProject.scala
+++ b/src/main/scala/org/ensime/maven/plugins/ensime/model/SubProject.scala
@@ -38,7 +38,8 @@ case class SubProject(
   targets: List[String],
   testTargets: List[String],
   dependsOnModules: List[String],
-  referenceSourceRoots: List[String])
+  referenceSourceRoots: List[String],
+  docJars: List[String])
 
 /**
  * A companion object for {@link SubProject}.
@@ -63,6 +64,7 @@ object SubProject {
         (SKeyword("targets") -> SList(subproject.targets.map(SString(_)))),
         (SKeyword("test-targets") -> SList(subproject.testTargets.map(SString(_)))),
         (SKeyword("reference-source-roots") -> SList(subproject.referenceSourceRoots.map(SString(_)))),
+        (SKeyword("doc-jars") -> SList(subproject.docJars.map(SString(_)))),
         (SKeyword("depends-on-modules") -> SList(subproject.dependsOnModules.map(SString(_))))))
   }
 }

--- a/src/test/scala/org/ensime/maven/plugins/ensime/model/ProjectSpec.scala
+++ b/src/test/scala/org/ensime/maven/plugins/ensime/model/ProjectSpec.scala
@@ -44,7 +44,8 @@ class ProjectSpec extends Specification {
         List("target"),
         List("test-target"),
         List("depends-1", "depends-2"),
-        List("depends-src-1", "depends-src-2"))),
+        List("depends-src-1", "depends-src-2"),
+        List("depends-doc-1", "depends-doc-2"))),
         FormatterPreferences())
 
       val expected = """(:root-dir
@@ -87,6 +88,9 @@ class ProjectSpec extends Specification {
                        |     :reference-source-roots
                        |       ("depends-src-1"
                        |        "depends-src-2")))
+                       |     :docJars
+                       |       ("depends-doc-1"
+                       |        "depends-doc-2")))
                        | :formatting-prefs
                        |   ())""".stripMargin
 

--- a/src/test/scala/org/ensime/maven/plugins/ensime/model/SubProjectSpec.scala
+++ b/src/test/scala/org/ensime/maven/plugins/ensime/model/SubProjectSpec.scala
@@ -44,7 +44,8 @@ class SubProjectSpec extends Specification {
         List("targets"),
         List("test-targets"),
         List("depends-1", "depends-2"),
-        List("depends-src-1", "depends-src-2"))
+        List("depends-src-1", "depends-src-2"),
+        List("depenfs-doc-1", "depends-doc-2"))
       subproject.as[SExpr].as[String] must equalTo("""(:name
                                                      |   "name"
                                                      | :module-name
@@ -70,7 +71,10 @@ class SubProjectSpec extends Specification {
                                                      |    "depends-2")
                                                      | :reference-source-roots
                                                      |   ("depends-src-1"
-                                                     |   "depends-src-2"))""".stripMargin)
+                                                     |   "depends-src-2")
+                                                     | :doc-jars
+                                                     |   ("depends-doc-1"
+                                                     |   "depends-doc-2"))""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
Hi,

I noticed that the :doc-jars tag was not supported by the maven plugin, so I added a quick and dirty fix.
Please not that the plugin does not download the javadocs automatically.

So before running the plugin please download the javadoc jars with:
mvn dependency:resolve -Dclassifier=javadoc

Hope this helps someone
Roll