### PR TITLE
Updated dependency generation to avoid cycles

### DIFF
--- a/src/main/java/org/ensime/maven/plugins/ensime/EnsimeConfigGenerator.java
+++ b/src/main/java/org/ensime/maven/plugins/ensime/EnsimeConfigGenerator.java
@@ -497,14 +497,13 @@ final public class EnsimeConfigGenerator {
 
       Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
 
-      // This only gets the direct dependencies, and we filter all the
-      // dependencies that are not a subproject of this potentially
-      // multiproject project
-      List<EnsimeProjectId> depends = modules.stream()
-        // .filter(d ->
-        //     modules.stream().filter(
-        //       m -> m.getId().equals(d.getId())).findFirst().isPresent())
-        .map(d -> new EnsimeProjectId(d.getArtifactId(), "compile"))
+      // Get project dependencies (maven subprojects) of this maven project --
+      // don't include this project as a dependency of itself
+      List<MavenProject> collectedProjects = project.getCollectedProjects();
+      List<EnsimeProjectId> depends = collectedProjects.stream()
+        .filter(p -> !p.getPackaging().equals("pom"))
+        .filter(p -> !p.getArtifactId().equals(project.getArtifactId()))
+        .map(p -> new EnsimeProjectId(p.getArtifactId(), "compile"))
         .collect(toList());
 
       List<String> compileSources = new ArrayList();


### PR DESCRIPTION
Currently, the ensime-maven plugin generates dependency cycles in the .ensime files it creates.  When run with the latest ensime-server with a scala project (java-only projects are not affected, and ensime 1.0 is not affected), this results in infinite recursion and stack overflow when starting the server.  For example, the following pom.xml results in a cyclic dependency in .ensime:

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
 
  <groupId>basic-company</groupId>
  <artifactId>basic</artifactId>
  <version>1.0-SNAPSHOT</version>
  <packaging>jar</packaging>

  <dependencies>
    <dependency>
      <groupId>net.alchim31.maven</groupId>
      <artifactId>scala-maven-plugin</artifactId>
      <version>3.2.2</version>
    </dependency>
  </dependencies>

  <build>
    <plugins>
      <plugin>
        <groupId>net.alchim31.maven</groupId>
        <artifactId>scala-maven-plugin</artifactId>
        <version>3.2.2</version>
        <configuration>
          <source>1.8</source>
          <target>1.8</target>
        </configuration>
        <executions>
          <execution>
            <id>scala-compile-first</id>
            <phase>process-resources</phase>
            <goals>
              <goal>add-source</goal>
              <goal>compile</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
  
</project>
```

I wasn't sure about desired testing for this, as there currently aren't any tests in ensime-maven.
