### PR TITLE
Do more complete search for project scala version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,13 @@
       <version>1.5.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>    
+
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/org/ensime/maven/plugins/ensime/GenerateMojo.java
+++ b/src/main/java/org/ensime/maven/plugins/ensime/GenerateMojo.java
@@ -75,6 +75,15 @@ final public class GenerateMojo extends AbstractMojo {
               defaultValue = "2.0.0-M4")
   protected String ensimeServerVersion;
 
+  /**
+   * Ensime Scala version
+   *
+   * If set (e.g. with -Densime.scala.version), the plugin will use this value
+   * instead of trying to dynamically determine project scala version.
+   */
+  @Parameter(property = "ensime.scala.version")
+  protected String ensimeScalaVersion;
+
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -98,7 +107,8 @@ final public class GenerateMojo extends AbstractMojo {
     }
 
     EnsimeConfigGenerator generator = new EnsimeConfigGenerator(project,
-        repoSystem, session, properties, ensimeServerVersion);
+        repoSystem, session, properties, ensimeServerVersion, ensimeScalaVersion,
+        getLog());
     generator.generate(new File(project.getBasedir(), DOT_ENSIME));
   }
 }

--- a/src/test/java/org/ensime/maven/plugins/ensime/EnsimeConfigGeneratorTest.java
+++ b/src/test/java/org/ensime/maven/plugins/ensime/EnsimeConfigGeneratorTest.java
@@ -1,0 +1,214 @@
+package org.ensime.maven.plugins.ensime;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Dependency;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.ensime.maven.plugins.ensime.EnsimeConfigGenerator.Pair;
+
+
+public class EnsimeConfigGeneratorTest {
+
+    @Test
+    public void testGetScalaVersionDefault() {
+        List<Dependency> directDependencies = new ArrayList<>();
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+        Set<Artifact> allDependencies = new HashSet<>();
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.9.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        assertEquals(result._1, defaultScalaVersion);
+        assertEquals(result._2, Optional.empty());
+    }
+
+    @Test
+    public void testGetScalaVersionDirect() throws Exception {
+        Dependency dep = new Dependency();
+        dep.setGroupId("org.scala-lang");
+        dep.setArtifactId("scala-library");
+        dep.setVersion("2.14.3");
+
+        Dependency dep2 = new Dependency();
+        dep2.setGroupId("org.scala-lang");
+        dep2.setArtifactId("scala-library");
+        dep2.setVersion("2.15.4");
+
+        ArtifactHandler ah = new DefaultArtifactHandler();
+        VersionRange vr3 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep3 = new DefaultArtifact("org.scala-lang", "scala-library", vr3, "compile", "jar", null, ah);
+        VersionRange vr4 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep4 = new DefaultArtifact("org.scala-lang", "scala-library", vr4, "compile", "jar", null, ah);
+        VersionRange vr5 = VersionRange.createFromVersionSpec("2.17.5");
+        Artifact dep5 = new DefaultArtifact("org.scala-lang", "scala-library", vr5, "compile", "jar", null, ah);
+        VersionRange vr6 = VersionRange.createFromVersionSpec("2.11.8");
+        Artifact dep6 = new DefaultArtifact("org.scala-lang", "scala-library", vr6, "compile", "jar", null, ah);
+
+        List<Dependency> directDependencies = new ArrayList<>();
+        directDependencies.add(dep);
+
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+        depMgmtDependencies.add(dep2);
+
+        Set<Artifact> allDependencies = new HashSet<>();
+        allDependencies.add(dep3);
+        allDependencies.add(dep4);
+        allDependencies.add(dep5);
+        allDependencies.add(dep6);
+
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.10.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        assertEquals(result._1, "2.14.3");
+        assertEquals(result._2, Optional.empty());
+    }
+
+    @Test
+    public void testGetScalaVersionDepMgmt() throws Exception {
+        Dependency dep2 = new Dependency();
+        dep2.setGroupId("org.scala-lang");
+        dep2.setArtifactId("scala-library");
+        dep2.setVersion("2.15.4");
+
+        ArtifactHandler ah = new DefaultArtifactHandler();
+        VersionRange vr3 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep3 = new DefaultArtifact("org.scala-lang", "scala-library", vr3, "compile", "jar", null, ah);
+        VersionRange vr4 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep4 = new DefaultArtifact("org.scala-lang", "scala-library", vr4, "compile", "jar", null, ah);
+        VersionRange vr5 = VersionRange.createFromVersionSpec("2.17.5");
+        Artifact dep5 = new DefaultArtifact("org.scala-lang", "scala-library", vr5, "compile", "jar", null, ah);
+        VersionRange vr6 = VersionRange.createFromVersionSpec("2.11.8");
+        Artifact dep6 = new DefaultArtifact("org.scala-lang", "scala-library", vr6, "compile", "jar", null, ah);
+
+        List<Dependency> directDependencies = new ArrayList<>();
+
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+        depMgmtDependencies.add(dep2);
+
+        Set<Artifact> allDependencies = new HashSet<>();
+        allDependencies.add(dep3);
+        allDependencies.add(dep4);
+        allDependencies.add(dep5);
+        allDependencies.add(dep6);
+
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.10.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        assertEquals(result._1, "2.15.4");
+        assertEquals(result._2, Optional.empty());
+    }
+
+    @Test
+    public void testGetScalaVersionAllDepSame() throws Exception {
+        ArtifactHandler ah = new DefaultArtifactHandler();
+        VersionRange vr3 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep3 = new DefaultArtifact("org.scala-lang", "scala-library", vr3, "compile", "jar", null, ah);
+        VersionRange vr4 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep4 = new DefaultArtifact("org.scala-lang", "scala-library", vr4, "compile", "jar", null, ah);
+
+        List<Dependency> directDependencies = new ArrayList<>();
+
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+
+        Set<Artifact> allDependencies = new HashSet<>();
+        allDependencies.add(dep3);
+        allDependencies.add(dep4);
+
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.10.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        assertEquals(result._1, "2.16.5");
+        assertEquals(result._2, Optional.empty());
+    }
+
+    @Test
+    public void testGetScalaVersionAllMajorSame() throws Exception {
+        ArtifactHandler ah = new DefaultArtifactHandler();
+        VersionRange vr3 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep3 = new DefaultArtifact("org.scala-lang", "scala-library", vr3, "compile", "jar", null, ah);
+        VersionRange vr4 = VersionRange.createFromVersionSpec("2.16.4");
+        Artifact dep4 = new DefaultArtifact("org.scala-lang", "scala-library", vr4, "compile", "jar", null, ah);
+
+        List<Dependency> directDependencies = new ArrayList<>();
+
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+
+        Set<Artifact> allDependencies = new HashSet<>();
+        allDependencies.add(dep3);
+        allDependencies.add(dep4);
+
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.10.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        assertEquals(result._1, "2.16.5");
+        String logMessage = "Multiple scala versions detected, using 2.16.5.  " +
+            "Use -Densime.scala.version to override.";
+        assertEquals(result._2, Optional.of(logMessage));
+    }
+
+    @Test
+    public void testGetScalaVersionAllMajorDifferent() throws Exception {
+        ArtifactHandler ah = new DefaultArtifactHandler();
+        VersionRange vr3 = VersionRange.createFromVersionSpec("2.17.8");
+        Artifact dep3 = new DefaultArtifact("org.scala-lang", "scala-library", vr3, "compile", "jar", null, ah);
+        VersionRange vr4 = VersionRange.createFromVersionSpec("2.16.9");
+        Artifact dep4 = new DefaultArtifact("org.scala-lang", "scala-library", vr4, "compile", "jar", null, ah);
+        VersionRange vr5 = VersionRange.createFromVersionSpec("2.17.5");
+        Artifact dep5 = new DefaultArtifact("org.scala-lang", "scala-library", vr5, "compile", "jar", null, ah);
+        VersionRange vr6 = VersionRange.createFromVersionSpec("2.16.5");
+        Artifact dep6 = new DefaultArtifact("org.scala-lang", "scala-library", vr6, "compile", "jar", null, ah);
+
+        List<Dependency> directDependencies = new ArrayList<>();
+
+        List<Dependency> depMgmtDependencies = new ArrayList<>();
+
+        Set<Artifact> allDependencies = new HashSet<>();
+        allDependencies.add(dep3);
+        allDependencies.add(dep4);
+        allDependencies.add(dep5);
+        allDependencies.add(dep6);
+
+        String ensimeScalaVersion = null;
+        String defaultScalaVersion = "2.10.6";
+
+        Pair<String, Optional<String>> result = EnsimeConfigGenerator.getScalaVersion(
+            directDependencies, depMgmtDependencies, allDependencies, ensimeScalaVersion,
+            defaultScalaVersion);
+
+        String logMessage = "Multiple scala versions detected, using 2.16.9.  " +
+            "Use -Densime.scala.version to override.";
+        assertEquals(result._1, "2.16.9");
+        assertEquals(result._2, Optional.of(logMessage));
+    }
+
+    
+}


### PR DESCRIPTION
Currently, `getScalaVersion()` calls `MavenProject.getDependencies()`, loops through them and looks for a scala-library dependency, and gets its version.  This works if the project directly declares a dependency on scala-library in its `<dependencies>`, but doesn't work if the project has only a transitive dependency on scala-library, or if the project declares a dependency on scala-library through `<dependencyManagement>` instead of through `<dependencies>`.  In these cases, scala-library is not found and the project uses the default scala version of 2.10.6.

It appears that `MavenProject.getDependencies()` only returns dependencies directly declared in the `<dependencies>` element of the `pom.xml`.  However, `MavenProject.getArtifacts()` appears to get all project dependencies, after transitive dependencies have been resolved.  This PR updates `getScalaVersion()` to use `getArtifacts()` instead of `getDependencies()`.

For example, the following `pom.xml` contains a transitive dependency to scala 2.11 through Apache Spark.  Currently, the generated `.ensime` will incorrectly use scala 2.10:

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
 
  <groupId>basic-company</groupId>
  <artifactId>basic</artifactId>
  <version>1.0-SNAPSHOT</version>
  <packaging>jar</packaging>

  <dependencies>
    <dependency>
      <groupId>net.alchim31.maven</groupId>
      <artifactId>scala-maven-plugin</artifactId>
      <version>3.2.2</version>
    </dependency>
    <dependency>
      <groupId>org.apache.spark</groupId>
      <artifactId>spark-core_2.11</artifactId>
      <version>2.1.1</version>
      <scope>provided</scope>
    </dependency>
  </dependencies>

  <build>
    <plugins>
      <plugin>
        <groupId>net.alchim31.maven</groupId>
        <artifactId>scala-maven-plugin</artifactId>
        <version>3.2.2</version>
        <configuration>
          <source>1.8</source>
          <target>1.8</target>
        </configuration>
        <executions>
          <execution>
            <id>scala-compile-first</id>
            <phase>process-resources</phase>
            <goals>
              <goal>add-source</goal>
              <goal>compile</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
  
</project>
```

For another example, you can download Apache Spark itself, and run ensime generate, which will also result in a `.ensime` using the default scala 2.10 even though it actually uses 2.11.  In this case, Spark declares its scala-library dependency in the `<dependencyManagement>` element.

This PR should resolve these issues.