### PR TITLE
Tools.jar does not exist in Java 9+, so look for an alternate file to…

### DIFF
--- a/src/main/java/org/ensime/maven/plugins/ensime/EnsimeConfigGenerator.java
+++ b/src/main/java/org/ensime/maven/plugins/ensime/EnsimeConfigGenerator.java
@@ -174,13 +174,20 @@ final public class EnsimeConfigGenerator {
     Optional<File> possibleJDK = possibleJDKs.flatMap( n -> {
       File f = new File(n + "/lib/tools.jar");
       if (f.exists())
-        return Stream.of(new File(n));
-      else return Stream.empty();
+          return Stream.of(new File(n));
+      // JDK 9+ has classlist but not tools.jar
+      else {
+          f = new File(n + "/lib/classlist");
+          if (f.exists())
+              return Stream.of(new File(n));
+          else
+              return Stream.empty();
+      }
     }).findFirst();
 
     if(!possibleJDK.isPresent()) {
       System.err.println(
-        "Could not automatically find the JDK/lib/tools.jar.\n" +
+        "Could not automatically find the JDK/lib/tools.jar (Java 1-8) or JDK/lib/classlist (Java 9+).\n" +
         "You must explicitly set JDK_HOME or JAVA_HOME.");
       System.exit(1);
     }


### PR DESCRIPTION
… confirm java home

With this change, `mvn ensime:generate` will work when the JDK is version 9 or higher.

It looks for `tools.jar` to maintain compatibility with Java 8-, and if it does not find it, looks for `lib/classlist`, which is a new file in JDK 9.